### PR TITLE
geth callback changed to include --syncmode flag

### DIFF
--- a/staging/values.yaml
+++ b/staging/values.yaml
@@ -3,7 +3,7 @@ image:
   repository: ethereum/client-go
   tag: latest
   pullPolicy: Always
-  command: 'geth --testnet --fast --cache=512 --rpc --rpccorsdomain "*" --rpcaddr "0.0.0.0"'
+  command: 'geth --testnet --syncmode "fast" --cache=512 --rpc --rpccorsdomain "*" --rpcaddr "0.0.0.0"'
 service:
   name: nginx
   type: NodePort


### PR DESCRIPTION
Updated command line options should reflect in `values.yaml`

https://github.com/ethereum/go-ethereum/wiki/Command-Line-Options